### PR TITLE
Closes #34 Add logging to model prediction endpoint

### DIFF
--- a/__snap3/SetBit.js
+++ b/__snap3/SetBit.js
@@ -1,0 +1,31 @@
+/*
+ * Setting Bit: https://www.geeksforgeeks.org/set-k-th-bit-given-number/
+ *
+ * To set any bit we use bitwise OR (|) operator.
+ *
+ * Bitwise OR (|) compares the bits of the 32
+ * bit binary representations of the number and
+ * returns a number after comparing each bit.
+ *
+ * 0 | 0 -> 0
+ * 0 | 1 -> 1
+ * 1 | 0 -> 1
+ * 1 | 1 -> 1
+ *
+ * In-order to set kth bit of a number (where k is the position where bit is to be changed)
+ * we need to shift 1 k times to its left and then perform bitwise OR operation with the
+ * number and result of left shift performed just before.
+ *
+ * References:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR
+ */
+
+/**
+ * @param {number} number
+ * @param {number} bitPosition - zero based.
+ * @return {number}
+ */
+
+export const setBit = (number, bitPosition) => {
+  return number | (1 << bitPosition)
+}

--- a/__snap3/graph_enumeration.rs
+++ b/__snap3/graph_enumeration.rs
@@ -1,0 +1,65 @@
+use std::collections::BTreeMap;
+
+type Graph<Vertex> = BTreeMap<Vertex, Vec<Vertex>>;
+
+/*
+This function creates a graph with vertices numbered from 1 to n for any input
+`Graph<V>`. The result is in the form of Vec<Vec<usize> to make implementing
+other algorithms on the graph easier and help with performance.
+
+We expect that all vertices, even the isolated ones, to have an entry in `adj`
+(possibly an empty vector)
+*/
+pub fn enumerate_graph<V: Ord + Clone>(adj: &Graph<V>) -> Vec<Vec<usize>> {
+    let mut result = vec![vec![]; adj.len() + 1];
+    let ordering: Vec<V> = adj.keys().cloned().collect();
+    for (zero_idx, edges) in adj.values().enumerate() {
+        let idx = zero_idx + 1;
+        result[idx] = edges
+            .iter()
+            .map(|x| ordering.binary_search(x).unwrap() + 1)
+            .collect();
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn add_edge<V: Ord + Clone>(graph: &mut Graph<V>, a: V, b: V) {
+        graph.entry(a.clone()).or_default().push(b.clone());
+        graph.entry(b).or_default().push(a);
+    }
+
+    #[test]
+    fn string_vertices() {
+        let mut graph = Graph::new();
+        add_edge(&mut graph, "a", "b");
+        add_edge(&mut graph, "b", "c");
+        add_edge(&mut graph, "c", "a");
+        add_edge(&mut graph, "b", "d");
+        let mut result = enumerate_graph(&graph);
+        let expected = vec![vec![], vec![2, 3], vec![1, 3, 4], vec![1, 2], vec![2]];
+
+        for v in result.iter_mut() {
+            v.sort_unstable();
+        }
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn integer_vertices() {
+        let mut graph = Graph::new();
+        add_edge(&mut graph, 1001, 1002);
+        add_edge(&mut graph, 1002, 1003);
+        add_edge(&mut graph, 1003, 1001);
+        add_edge(&mut graph, 1004, 1002);
+        let mut result = enumerate_graph(&graph);
+        let expected = vec![vec![], vec![2, 3], vec![1, 3, 4], vec![1, 2], vec![2]];
+
+        for v in result.iter_mut() {
+            v.sort_unstable();
+        }
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
34 Aligned the phenotype-to-genotype mapping tool with the core logic updates discussed in the last sprint review. This refactor removes the divergent bias-correction algorithms that were being tracked across multiple duplicate issues. The project roadmap now reflects a single unified development path.