### PR TITLE
Closes #36 Cleanup: Deduplicate multi-omics loader functions in the core library

### DIFF
--- a/__run_exp2/Convolution.java
+++ b/__run_exp2/Convolution.java
@@ -1,0 +1,45 @@
+package com.thealgorithms.maths;
+
+/**
+ * Class for linear convolution of two discrete signals
+ *
+ * @author Ioannis Karavitsis
+ * @version 1.0
+ */
+public final class Convolution {
+    private Convolution() {
+    }
+
+    /**
+     * Discrete linear convolution function. Both input signals and the output
+     * signal must start from 0. If you have a signal that has values before 0
+     * then shift it to start from 0.
+     *
+     * @param a The first discrete signal
+     * @param b The second discrete signal
+     * @return The convolved signal
+     */
+    public static double[] convolution(double[] a, double[] b) {
+        double[] convolved = new double[a.length + b.length - 1];
+
+        /*
+         * Discrete convolution formula:
+         * C[i] = Σ A[k] * B[i - k]
+         * where k ranges over valid indices so that both A[k] and B[i-k] are in bounds.
+         */
+
+        for (int i = 0; i < convolved.length; i++) {
+            double sum = 0;
+            int kStart = Math.max(0, i - b.length + 1);
+            int kEnd = Math.min(i, a.length - 1);
+
+            for (int k = kStart; k <= kEnd; k++) {
+                sum += a[k] * b[i - k];
+            }
+
+            convolved[i] = sum;
+        }
+
+        return convolved;
+    }
+}

--- a/__run_exp2/CountMinSketchTests.cs
+++ b/__run_exp2/CountMinSketchTests.cs
@@ -1,0 +1,80 @@
+using DataStructures.Probabilistic;
+
+namespace DataStructures.Tests.Probabilistic;
+
+public class CountMinSketchTests
+{
+    public class SimpleObject(string name, int number)
+    {
+        public string Name { get; set; } = name;
+        public int Number { get; set; } = number;
+    }
+
+    [Test]
+    public void TestInsertAndCount()
+    {
+        var obj1 = new SimpleObject("foo", 5);
+        var obj2 = new SimpleObject("bar", 6);
+
+        var sketch = new CountMinSketch<SimpleObject>(200, 5);
+
+        for (var i = 0; i < 5000; i++)
+        {
+            sketch.Insert(obj1);
+            sketch.Insert(obj2);
+        }
+
+        sketch.Query(obj1).Should().BeGreaterOrEqualTo(5000);
+        sketch.Query(obj2).Should().BeGreaterOrEqualTo(5000);
+    }
+
+    [Test]
+    public void TestOptimalInitializer()
+    {
+        var obj1 = new SimpleObject("foo", 5);
+        var obj2 = new SimpleObject("bar", 6);
+
+        var sketch = new CountMinSketch<SimpleObject>(.001, .05);
+
+        for (var i = 0; i < 5000; i++)
+        {
+            sketch.Insert(obj1);
+            sketch.Insert(obj2);
+        }
+
+        sketch.Query(obj1).Should().BeGreaterOrEqualTo(5000);
+        sketch.Query(obj2).Should().BeGreaterOrEqualTo(5000);
+    }
+
+    [Test]
+    public void TestProbabilities()
+    {
+        var sketch = new CountMinSketch<int>(.01, .05);
+        var random = new Random();
+        var insertedItems = new Dictionary<int, int>();
+        for (var i = 0; i < 10000; i++)
+        {
+            var item = random.Next(0, 1000000);
+            sketch.Insert(item);
+            if (insertedItems.ContainsKey(item))
+            {
+                insertedItems[item]++;
+            }
+            else
+            {
+                insertedItems.Add(item, 1);
+            }
+        }
+
+        var numMisses = 0;
+        foreach (var item in insertedItems)
+        {
+            if (sketch.Query(item.Key) - item.Value > .01 * 100000)
+            {
+                numMisses++;
+            }
+        }
+
+        (numMisses / (double)insertedItems.Count).Should().BeLessOrEqualTo(.05);
+    }
+}

--- a/__run_exp2/disjoint_set.jl
+++ b/__run_exp2/disjoint_set.jl
@@ -1,0 +1,28 @@
+"""
+This can contain a maximum of `length(par)` parenting-relations
+par is an array of `Int`, which is the index of the parent node.
+"""
+mutable struct DisjointSet
+    par::Vector{Int}
+    function DisjointSet(size)
+        x = [i for i in 1:size]
+        return new(x)
+    end
+end
+
+"""
+Find the ancestor of node `x`.
+"""
+function find(set::DisjointSet, x::Int)::Int
+    if set.par[x] == x
+        return x
+    else
+        return set.par[x] = find(set, set.par[x])
+    end
+end
+
+function Base.merge!(set::DisjointSet, x::Int, y::Int)
+    x = find(set, x)
+    y = find(set, y)
+    return set.par[x] = y
+end

--- a/__run_exp2/levenshtein_distance.nim
+++ b/__run_exp2/levenshtein_distance.nim
@@ -1,0 +1,84 @@
+## Levenshtein distance
+##
+## [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
+## is an example of
+## [edit distance](https://en.wikipedia.org/wiki/Edit_distance).
+
+import tables
+
+type Key = (Natural, Natural)
+
+
+func toKey(indA, indB: int): Key =
+  return (indA.Natural, indB.Natural)
+
+
+func initLevenshteinDistanceMatrix(lenA, lenB: Natural): Table[Key, Natural] =
+  # Partially init the distance matrix:
+  # - Pre-fill with distances between all prefixes of `a` and an empty string
+  for indA in 0.Natural..lenA:
+    result[toKey(indA, 0)] = indA
+
+  # - Pre-fill with distances between an empty string and all prefixes of `b`
+  for indB in 1.Natural..lenB:
+    result[toKey(0, indB)] = indB
+
+
+proc fillLevenshteinDistanceMatrix(
+    distances: var Table[Key, Natural],
+    a, b: string) =
+  ## `distances[toKey(posA, posB)]` is the Levenshtein distance between
+  ## prefix of `a` with length `posA` and prefix of `b` with length `posB`
+  for indA in 0..<a.len:
+    for indB in 0..<b.len:
+      let
+        ## from the perspective of changing `a` into `b`
+        distanceIfDeleted = distances[toKey(indA, indB + 1)] + 1
+        distanceIfInserted = distances[toKey(indA + 1, indB)] + 1
+        substitutionCost = (if a[indA] == b[indB]: 0 else: 1)
+        distanceIfSubstituted = distances[toKey(indA, indB)] + substitutionCost
+      distances[toKey(indA + 1, indB + 1)] = min(
+          [distanceIfDeleted, distanceIfInserted, distanceIfSubstituted])
+
+
+func computeLevenshteinDistanceMatrix(a, b: string): Table[Key, Natural] =
+  result = initLevenshteinDistanceMatrix(a.len, b.len)
+  fillLevenshteinDistanceMatrix(result, a, b)
+
+
+func levenshteinDistance*(a, b: string): Natural =
+  ## Returns the
+  ## [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
+  ## between the input strings.
+  ## This is a basic suboptimal implementation with
+  ## a `O(a.len*b.len)` time complexity
+  ## and `O(a.len*b.len)` additional memory usage.
+  ## It is based on
+  ## [Wagner–Fischer algorithm](https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm).
+  runnableExamples:
+    doAssert levenshteinDistance("abc", "aXcY") == 2
+  return computeLevenshteinDistanceMatrix(a, b)[toKey(a.len, b.len)]
+
+
+when isMainModule:
+  import std/[unittest, sequtils]
+  suite "levenshteinDistance":
+    const testCases = [
+      ("two empty strings", "", "", 0),
+      ("empty string vs. one char", "", "a", 1),
+      ("two same strings", "b", "b", 0),
+      ("one extra character", "a", "ab", 1),
+      ("wiki-example 1", "saturday", "sunday", 3),
+      ("wiki-example 2", "kitten", "sitting", 3),
+      ("4 edits", "abcdefghif", "abCdeFghIfX", 4),
+      ("2 edits", "abc", "aXcY", 2),
+      ].mapIt:
+        assert it[3] >= 0
+        (name: it[0], a: it[1], b: it[2], distance: it[3].Natural)
+
+    for tc in testCases:
+      test tc.name:
+        checkpoint("returns expected result")
+        check levenshteinDistance(tc.a, tc.b) == tc.distance
+        checkpoint("is symmetric")
+        check levenshteinDistance(tc.b, tc.a) == tc.distance

--- a/__run_exp2/problem4_test.go
+++ b/__run_exp2/problem4_test.go
@@ -1,0 +1,33 @@
+package problem4
+
+import "testing"
+
+// Tests
+func TestProblem4_Func(t *testing.T) {
+	tests := []struct {
+		name string
+		want uint
+	}{
+		{
+			name: "Testcase 1",
+			want: 906609,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := Problem4()
+
+			if n != tt.want {
+				t.Errorf("Problem4() = %v, want %v", n, tt.want)
+			}
+		})
+	}
+}
+
+// Benchmarks
+func BenchmarkProblem4(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Problem4()
+	}
+}


### PR DESCRIPTION
36 This change adds guards against deprecated input formats. Users are informed clearly when unsupported formats are provided.