### PR TITLE
Closes #47 Refactor: Consolidate secondary reports on sequence pre-fetch drift

### DIFF
--- a/__dev1/Area.sol
+++ b/__dev1/Area.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+/**
+ * @title Calculate the area of various shapes
+ * @author [Perelyn](https://github.com/Perelyn-sama)
+ */
+contract Area is Test {
+    /**
+     *@notice Calculate the Surface Area of a Cube.
+     * @dev https://en.wikipedia.org/wiki/Area#Surface_area
+     * @param _side - Integer
+     * @return _result - 6 * side ** 2
+     */
+    function surfaceAreaCube(uint256 _side)
+        public
+        pure
+        returns (uint256 _result)
+    {
+        _result = 6 * _side**2;
+    }
+
+    /**
+     *@notice Calculate the Surface Area of a Sphere.
+     * @dev https://en.wikipedia.org/wiki/Sphere
+     * @param _radius - Integer
+     * @return _result - 4 * pi * r^2
+     */
+    function surfaceAreaSphere(uint256 _radius)
+        public
+        pure
+        returns (uint256 _result)
+    {
+        uint256 PI_IN_WEI = 3141590000000000000;
+        _result = (4 * PI_IN_WEI * _radius**2) / 1e18;
+    }
+
+    /**
+     *@notice Calculate the area of a rectangle.
+     * @dev https://en.wikipedia.org/wiki/Area#Quadrilateral_area
+     * @param _length - Integer
+     * @param  _width - Integer
+     * @return _result - width * length
+     */
+    function areaRectangle(uint256 _width, uint256 _length)
+        public
+        pure
+        returns (uint256 _result)
+    {
+        _result = _width * _length;
+    }
+
+    /**
+     *@notice Calculate the area of a square.
+     * @dev https://en.wikipedia.org/wiki/Square
+     * @param _side - Integer
+     * @return _result - side ** 2.
+     */
+    function areaSquare(uint256 _side) public pure returns (uint256 _result) {
+        _result = _side**2;
+    }
+
+    /**
+     *@notice Calculate the area of a triangle.
+     * @dev https://en.wikipedia.org/wiki/Area#Triangle_area
+     * @param _base - Integer
+     * @param _height - Integer
+     * @return _result - base * height / 2.
+     */
+    function areaTriangle(uint256 _base, uint256 _height)
+        public
+        pure
+        returns (uint256 _result)
+    {
+        _result = (_base * _height) / 2.0;
+    }
+
+    /**
+     *@notice Calculate the area of a parallelogram.
+     * @dev https://en.wikipedia.org/wiki/Area#Dissection,_parallelograms,_and_triangles
+     * @param _base - Integer
+     * @param _height - Integer
+     * @return _result - base * height
+     */
+    function areaParallelogram(uint256 _base, uint256 _height)
+        public
+        pure
+        returns (uint256 _result)
+    {
+        _result = _base * _height;
+    }
+
+    /**
+     *@notice Calculate the area of a trapezium.
+     * @dev https://en.wikipedia.org/wiki/Trapezoid
+     * @param _base1 - Integer
+     * @param _base2 - Integer
+     * @param _height - Integer
+     * @return _result (1 / 2) * (base1 + base2) * height
+     */
+    function areaTrapezium(
+        uint256 _base1,
+        uint256 _base2,
+        uint256 _height
+    ) public pure returns (uint256 _result) {
+        uint256 HALF_IN_WEI = 500000000000000000;
+        _result = (HALF_IN_WEI * (_base1 + _base2) * _height) / 1e18;
+    }
+
+    /**
+     *@notice Calculate the area of a circle.
+     * @dev https://en.wikipedia.org/wiki/Area_of_a_circle
+     * @param _radius - Integer
+     * @return _result - Math.PI * radius ** 2
+     */
+    function areaCircle(uint256 _radius) public pure returns (uint256 _result) {
+        uint256 PI_IN_WEI = 3141590000000000000;
+        _result = (PI_IN_WEI * _radius**2) / 1e18;
+    }
+
+    /**
+     *@notice Calculate the area of a rhombus.
+     * @dev https://en.wikipedia.org/wiki/
+     * @param _diagonal1 - Integer
+     * @param _diagonal2 - Integer
+     * @return _result - (1 / 2) * diagonal1 * diagonal2
+     */
+    function areaRhombus(uint256 _diagonal1, uint256 _diagonal2)
+        public
+        pure
+        returns (uint256 _result)
+    {
+        uint256 HALF_IN_WEI = 500000000000000000;
+        _result = (HALF_IN_WEI * _diagonal1 * _diagonal2) / 1e18;
+    }
+}

--- a/__dev1/binarytodecimal.go
+++ b/__dev1/binarytodecimal.go
@@ -1,0 +1,42 @@
+/*
+Author: Motasim
+GitHub: https://github.com/motasimmakki
+Date: 19-Oct-2021
+*/
+
+// This algorithm will convert any Binary number(0 or 1) to Decimal number(+ve number).
+// https://en.wikipedia.org/wiki/Binary_number
+// https://en.wikipedia.org/wiki/Decimal
+// Function receives a Binary Number as string and returns the Decimal number as integer.
+// Supported Binary number range is 0 to 2^(31-1).
+// time complexity: O(n)
+// space complexity: O(1)
+
+package conversion
+
+// Importing necessary package.
+import (
+	"errors"
+	"regexp"
+)
+
+var isValid = regexp.MustCompile("^[0-1]{1,}$").MatchString
+
+// BinaryToDecimal() function that will take Binary number as string,
+// and return its Decimal equivalent as an integer.
+func BinaryToDecimal(binary string) (int, error) {
+	if !isValid(binary) {
+		return -1, errors.New("not a valid binary string")
+	}
+	if len(binary) > 32 {
+		return -1, errors.New("binary number must be in range 0 to 2^(31-1)")
+	}
+	var result, base int = 0, 1
+	for i := len(binary) - 1; i >= 0; i-- {
+		if binary[i] == '1' {
+			result += base
+		}
+		base *= 2
+	}
+	return result, nil
+}

--- a/__dev1/decimal_to_hexadecimal.py
+++ b/__dev1/decimal_to_hexadecimal.py
@@ -1,0 +1,80 @@
+"""Convert Base 10 (Decimal) Values to Hexadecimal Representations"""
+
+# set decimal value for each hexadecimal digit
+values = {
+    0: "0",
+    1: "1",
+    2: "2",
+    3: "3",
+    4: "4",
+    5: "5",
+    6: "6",
+    7: "7",
+    8: "8",
+    9: "9",
+    10: "a",
+    11: "b",
+    12: "c",
+    13: "d",
+    14: "e",
+    15: "f",
+}
+
+
+def decimal_to_hexadecimal(decimal: float) -> str:
+    """
+    take integer decimal value, return hexadecimal representation as str beginning
+    with 0x
+    >>> decimal_to_hexadecimal(5)
+    '0x5'
+    >>> decimal_to_hexadecimal(15)
+    '0xf'
+    >>> decimal_to_hexadecimal(37)
+    '0x25'
+    >>> decimal_to_hexadecimal(255)
+    '0xff'
+    >>> decimal_to_hexadecimal(4096)
+    '0x1000'
+    >>> decimal_to_hexadecimal(999098)
+    '0xf3eba'
+    >>> # negatives work too
+    >>> decimal_to_hexadecimal(-256)
+    '-0x100'
+    >>> # floats are acceptable if equivalent to an int
+    >>> decimal_to_hexadecimal(17.0)
+    '0x11'
+    >>> # other floats will error
+    >>> decimal_to_hexadecimal(16.16) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    AssertionError
+    >>> # strings will error as well
+    >>> decimal_to_hexadecimal('0xfffff') # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    AssertionError
+    >>> # results are the same when compared to Python's default hex function
+    >>> decimal_to_hexadecimal(-256) == hex(-256)
+    True
+    """
+    assert isinstance(decimal, (int, float))
+    assert decimal == int(decimal)
+    decimal = int(decimal)
+    hexadecimal = ""
+    negative = False
+    if decimal < 0:
+        negative = True
+        decimal *= -1
+    while decimal > 0:
+        decimal, remainder = divmod(decimal, 16)
+        hexadecimal = values[remainder] + hexadecimal
+    hexadecimal = "0x" + hexadecimal
+    if negative:
+        hexadecimal = "-" + hexadecimal
+    return hexadecimal
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
47 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.