### PR TITLE
Closes #51 Fix: Restore index pointer integrity in the BAM-to-parquet engine

### DIFF
--- a/__notes9/064_shortest_path_Rust.rs
+++ b/__notes9/064_shortest_path_Rust.rs
@@ -1,0 +1,190 @@
+// bfs_unweighted.rs
+// Breadth-first search (BFS) shortest path on an unweighted, undirected graph.
+//
+// INPUT FORMAT (tab- or space-separated; one edge per line; queries start with '#'):
+//   A   B   F
+//   B   A   C
+//   C   B   D
+//   D   C   E
+//   E   D   F
+//   F   A   E
+//   #   A   E
+//
+// USAGE
+//   rustc bfs_unweighted.rs && ./bfs_unweighted graph.tsv
+//   # or pipe:
+//   cat graph.tsv | ./bfs_unweighted
+//
+// OUTPUT
+//   One line per query, either "SRC -> ... -> DST" or an explanatory message.
+
+use std::collections::{HashMap, VecDeque};
+use std::env;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::process;
+
+type Adj = HashMap<String, Vec<String>>;
+#[derive(Clone)]
+struct Query {
+    src: String,
+    dst: String,
+}
+
+fn main() {
+    // Input: file path in argv[1] or stdin
+    let args: Vec<String> = env::args().collect();
+    let reader: Box<dyn BufRead> = if args.len() >= 2 {
+        match File::open(&args[1]) {
+            Ok(f) => Box::new(BufReader::new(f)),
+            Err(e) => {
+                eprintln!("Failed to open {}: {}", args[1], e);
+                process::exit(1);
+            }
+        }
+    } else {
+        Box::new(BufReader::new(io::stdin()))
+    };
+
+    let (adj, queries) = parse_input(reader);
+
+    if queries.is_empty() {
+        println!(r#"No queries found (expect lines like: "#  SRC  DST"). Nothing to do."#);
+        return;
+    }
+
+    for q in queries {
+        if q.src == q.dst {
+            println!("{}", q.src);
+            continue;
+        }
+        if !adj.contains_key(&q.src) {
+            println!("No path found from {} to {} (source not in graph)", q.src, q.dst);
+            continue;
+        }
+        if !adj.contains_key(&q.dst) {
+            println!("No path found from {} to {} (destination not in graph)", q.src, q.dst);
+            continue;
+        }
+        match bfs_path(&adj, &q.src, &q.dst) {
+            Some(path) => println!("{}", path.join(" -> ")),
+            None => println!("No path found from {} to {}", q.src, q.dst),
+        }
+    }
+}
+
+//--------------------------- Parsing & Utilities ---------------------------//
+
+// Lines beginning with '#' are queries: "# SRC DST"
+// Other lines: "U V1 [V2 ...]" = undirected edges U—V1, U—V2, ...
+fn parse_input<R: BufRead>(mut reader: R) -> (Adj, Vec<Query>) {
+    let mut adj: Adj = HashMap::new();
+    let mut queries: Vec<Query> = Vec::new();
+
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        let n = reader.read_line(&mut buf).unwrap_or(0);
+        if n == 0 {
+            break;
+        }
+        let line = buf.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut toks = line.split_whitespace();
+        let first = match toks.next() {
+            Some(x) => x,
+            None => continue,
+        };
+
+        if first.starts_with('#') {
+            // Query line
+            let src = match toks.next() {
+                Some(s) => s.to_string(),
+                None => continue, // malformed query; skip
+            };
+            let dst = match toks.next() {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            queries.push(Query { src, dst });
+        } else {
+            // Edge list: u v1 v2 ...
+            let u = first.to_string();
+            let neighbors: Vec<String> = toks.map(|s| s.to_string()).collect();
+            if neighbors.is_empty() {
+                continue; // malformed; skip
+            }
+            for v in neighbors {
+                add_undirected_edge(&mut adj, &u, &v);
+            }
+        }
+    }
+
+    (adj, queries)
+}
+
+fn add_undirected_edge(adj: &mut Adj, u: &str, v: &str) {
+    add_directed_unique(adj, u, v);
+    add_directed_unique(adj, v, u);
+}
+
+fn add_directed_unique(adj: &mut Adj, u: &str, v: &str) {
+    let entry = adj.entry(u.to_string()).or_insert_with(Vec::new);
+    if !entry.iter().any(|x| x == v) {
+        entry.push(v.to_string());
+    }
+    // Ensure v exists as a key too (even if no outgoing yet), so membership checks work
+    adj.entry(v.to_string()).or_insert_with(Vec::new);
+}
+
+//--------------------------- BFS Shortest Path -----------------------------//
+
+fn bfs_path(adj: &Adj, src: &str, dst: &str) -> Option<Vec<String>> {
+    if src == dst {
+        return Some(vec![src.to_string()]);
+    }
+
+    let mut visited: HashMap<&str, bool> = HashMap::new();
+    let mut parent: HashMap<&str, &str> = HashMap::new();
+    let mut q: VecDeque<&str> = VecDeque::new();
+
+    visited.insert(src, true);
+    q.push_back(src);
+
+    while let Some(u) = q.pop_front() {
+        if let Some(nei) = adj.get(u) {
+            for v in nei {
+                let v_str: &str = v.as_str();
+                if !visited.contains_key(v_str) {
+                    visited.insert(v_str, true);
+                    parent.insert(v_str, u);
+                    if v_str == dst {
+                        return Some(reconstruct(&parent, src, dst));
+                    }
+                    q.push_back(v_str);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn reconstruct(parent: &HashMap<&str, &str>, src: &str, dst: &str) -> Vec<String> {
+    let mut path: Vec<String> = Vec::new();
+    let mut cur = dst;
+    path.push(cur.to_string());
+    while cur != src {
+        if let Some(&p) = parent.get(cur) {
+            cur = p;
+            path.push(cur.to_string());
+        } else {
+            // Shouldn't happen if called correctly; return minimal path
+            break;
+        }
+    }
+    path.reverse();
+    path
+}
+

--- a/__notes9/ProcessDetails.java
+++ b/__notes9/ProcessDetails.java
@@ -1,0 +1,67 @@
+package com.thealgorithms.devutils.entities;
+
+public class ProcessDetails {
+    private String processId;
+    private int arrivalTime;
+    private int burstTime;
+    private int waitingTime;
+    private int turnAroundTime;
+    private int priority;
+
+    public ProcessDetails(final String processId, final int arrivalTime, final int burstTime, int priority) {
+        this.processId = processId;
+        this.arrivalTime = arrivalTime;
+        this.burstTime = burstTime;
+        this.priority = priority;
+    }
+
+    public ProcessDetails(final String processId, final int arrivalTime, final int burstTime) {
+        this.processId = processId;
+        this.arrivalTime = arrivalTime;
+        this.burstTime = burstTime;
+    }
+
+    public String getProcessId() {
+        return processId;
+    }
+
+    public int getArrivalTime() {
+        return arrivalTime;
+    }
+
+    public int getBurstTime() {
+        return burstTime;
+    }
+
+    public int getWaitingTime() {
+        return waitingTime;
+    }
+
+    public int getTurnAroundTimeTime() {
+        return turnAroundTime;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setProcessId(final String processId) {
+        this.processId = processId;
+    }
+
+    public void setArrivalTime(final int arrivalTime) {
+        this.arrivalTime = arrivalTime;
+    }
+
+    public void setBurstTime(final int burstTime) {
+        this.burstTime = burstTime;
+    }
+
+    public void setWaitingTime(final int waitingTime) {
+        this.waitingTime = waitingTime;
+    }
+
+    public void setTurnAroundTimeTime(final int turnAroundTime) {
+        this.turnAroundTime = turnAroundTime;
+    }
+}

--- a/__notes9/pascals_triangle.test.ts
+++ b/__notes9/pascals_triangle.test.ts
@@ -1,0 +1,11 @@
+import { pascalsTriangle } from '../pascals_triangle'
+
+describe('pascalsTriangle', () => {
+  it.each([
+    [2, [1, 1]],
+    [4, [1, 3, 3, 1]],
+    [6, [1, 5, 10, 10, 5, 1]]
+  ])('The %i th row should equal to %i', (n, expectation) => {
+    expect(pascalsTriangle(n)).toEqual(expectation)
+  })
+})

--- a/__notes9/tanh.rs
+++ b/__notes9/tanh.rs
@@ -1,0 +1,34 @@
+//Rust implementation of the Tanh (hyperbolic tangent) activation function.
+//The formula for Tanh: (e^x - e^(-x))/(e^x + e^(-x)) OR (2/(1+e^(-2x))-1
+//More information on the concepts of Sigmoid can be found here:
+//https://en.wikipedia.org/wiki/Hyperbolic_functions
+
+//The function below takes a reference to a mutable <f32> Vector as an argument
+//and returns the vector with 'Tanh' applied to all values.
+//Of course, these functions can be changed by the developer so that the input vector isn't manipulated.
+//This is simply an implemenation of the formula.
+
+use std::f32::consts::E;
+
+pub fn tanh(array: &mut Vec<f32>) -> &mut Vec<f32> {
+    //note that these calculations are assuming the Vector values consists of real numbers in radians
+    for value in &mut *array {
+        *value = (2. / (1. + E.powf(-2. * *value))) - 1.;
+    }
+
+    array
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tanh() {
+        let mut test = Vec::from([1.0, 0.5, -1.0, 0.0, 0.3]);
+        assert_eq!(
+            tanh(&mut test),
+            &mut Vec::<f32>::from([0.76159406, 0.4621172, -0.7615941, 0.0, 0.29131258,])
+        );
+    }
+}


### PR DESCRIPTION
51 Guidance on model versioning across environments was added. The recommendations are intentionally flexible and non-prescriptive.